### PR TITLE
break docker build cache based on time stamp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM node:4.1.0-slim
+ENV REFRESHED_AT 2015_02_20
 
 RUN wget https://github.com/tantaman/Strut/archive/master.tar.gz -O ./Strut.tar.gz \
  && tar zxvf ./Strut.tar.gz \


### PR DESCRIPTION
Hi there,

i like your container providing easy access to strut. Nevertheless i would suggest you to add an environment variable right after the 'FROM' statement. Like this:

``` yml
FROM node:4.1.0-slim
ENV REFRESHED_AT 2015_02_20
```

It shows at which date your image is updated. It is beneficial especially when you provide access to an master-branch project. So you can update this environment variable and your automatic build in docker hub is triggered with this time-stamped master-branch checkout.

Additionally other users can provide pull requests, updating this environment variable to generate a new master snapshot.
